### PR TITLE
Turn off scroll zoom for chapter map

### DIFF
--- a/00004/index.html
+++ b/00004/index.html
@@ -28,7 +28,7 @@
 <div id='map'></div>
 <script type='text/javascript'>
 
-var map = L.mapbox.map('map', null, {touchZoom: false, scrollWheelZoom: true});
+var map = L.mapbox.map('map', null, {touchZoom: false, scrollWheelZoom: false});
 //var stamenLayer = L.tileLayer('http://{s}.sm.mapstack.stamen.com/(toner-lite,(watercolor,$fff%5B@0%5D,$fff%5Bhsl-saturation@50%5D,mapbox-water%5Bdestination-in%5D)%5B@50%5D/{z}/{x}/{y}.png')
 var stamenLayer = L.tileLayer('http://{s}.sm.mapstack.stamen.com/((watercolor,mapbox-water[destination-in]),toner-lite[multiply],$ffffff[@50p])/{z}/{x}/{y}.png')
 		.addTo(map);


### PR DESCRIPTION
(Redo, merging to correct branch!) Scroll zoom on the map was really annoying on the new website. We can either turn it off unilaterally here, or make a different map for the new website.
